### PR TITLE
add keyboard + gamepad input

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,6 +11,7 @@ fs.copySync('./node_modules/electron/dist', outputDir);
 fs.emptyDirSync(path.join(outputDir, 'resources/app'));
 fs.copySync('./src', path.join(outputDir, 'resources/app/src'));
 fs.copySync('./package.json', path.join(outputDir, 'resources/app/package.json'));
+fs.copySync('./node_modules/input-gamepads.js/dist/index.iife.js', path.join(outputDir, 'resources/app/node_modules/input-gamepads.js/dist/index.iife.js'));
 rcedit(path.join(outputDir, 'electron.exe'), {
 	'version-string': package.version,
 	'file-version': package.version,

--- a/package-lock.json
+++ b/package-lock.json
@@ -428,6 +428,11 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
+    "input-gamepads.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/input-gamepads.js/-/input-gamepads.js-2.0.2.tgz",
+      "integrity": "sha512-9QEIwT6PbLsaCREQPNnG5TOrQBQg5b211WaaHuuTzBdZ9Cj1fkpnuG6G+TBVnX3BFJQPsrwzkqoiiQCp6s1/TQ=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "electron": "^5.0.7",
     "fs-extra": "^8.1.0",
     "rcedit": "^2.0.0"
+  },
+  "dependencies": {
+    "input-gamepads.js": "^2.0.2"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<link rel="icon" type="image/png" href="./icon.ico">
 
+	<script src="../node_modules/input-gamepads.js/dist/index.iife.js"></script>
 	<script src="./mixtapeData.js"></script>
 	<script src="./mixtapePlayer.js"></script>
 

--- a/src/mixtapePlayer.js
+++ b/src/mixtapePlayer.js
@@ -60,12 +60,13 @@ function makeGameCard(gameId) {
 	var game = mixtape_games[gameId];
 
 	var card = document.createElement("button");
-	card.onclick = function () {
+	card.onfocus = function () {
 		if (selectedGameId != gameId) {
 			selectGame(gameId, slowTimer);
-		} else {
-			playGame(gameId);
 		}
+	};
+	card.ondblclick = function () {
+		playGame(gameId);
 	};
 	card.id = "card_" + gameId;
 	card.classList.add("game_card");

--- a/src/mixtapePlayer.js
+++ b/src/mixtapePlayer.js
@@ -119,6 +119,7 @@ function selectGame(gameId, timer) {
 		behavior: 'smooth',
 		block: 'center',
 	});
+	selectedCard.focus();
 
 	document.getElementById("select_screen").style.backgroundColor = game.colors[0];
 	document.getElementById("select_screen").style.color = game.colors[1];

--- a/src/mixtapePlayer.js
+++ b/src/mixtapePlayer.js
@@ -305,3 +305,50 @@ window.addEventListener('keydown', function ({
 			return;
 	}
 });
+
+// gamepad input
+
+const gamepads = window.inputGamepads;
+gamepads.init();
+
+function gamepadUpdate() {
+	let x = 0;
+	let y = 0;
+	let confirm = false;
+	let cancel = false;
+	if (gamepads.isJustDown(gamepads.DPAD_RIGHT) || gamepads.axisJustPast(gamepads.LSTICK_H, 0.5, 1)) {
+		x += 1;
+	}
+	if (gamepads.isJustDown(gamepads.DPAD_LEFT) || gamepads.axisJustPast(gamepads.LSTICK_H, -0.5, -1)) {
+		x -= 1;
+	}
+	if (gamepads.isJustDown(gamepads.DPAD_DOWN) || gamepads.axisJustPast(gamepads.LSTICK_V, 0.5, 1)) {
+		y += 1;
+	}
+	if (gamepads.isJustDown(gamepads.DPAD_UP) || gamepads.axisJustPast(gamepads.LSTICK_V, -0.5, -1)) {
+		y -= 1;
+	}
+	if (gamepads.isJustDown(gamepads.A) || gamepads.isJustDown(gamepads.START)) {
+		confirm = true;
+	}
+	if (gamepads.isJustDown(gamepads.BACK)) {
+		cancel = true;
+	}
+
+	onInput({
+		x,
+		y,
+		confirm,
+		cancel,
+	});
+
+	gamepads.update();
+}
+
+function loop(fn) {
+	(function l() {
+		fn();
+		requestAnimationFrame(l);
+	}());
+}
+loop(gamepadUpdate);

--- a/src/mixtapePlayer.js
+++ b/src/mixtapePlayer.js
@@ -202,3 +202,38 @@ function exitPlayScreen() {
 function restartGame() {
 	playGame(selectedGameId);
 }
+
+// genericized input
+function onInput({
+	x = 0,
+}) {
+	if (x > 0) {
+		const card = document.getElementById("card_" + selectedGameId);
+		const target = card.nextSibling || card.parentElement.children[0];
+		target.focus();
+	} else if (x < 0) {
+		const card = document.getElementById("card_" + selectedGameId);
+		const target = card.previousSibling || card.parentElement.children[card.parentElement.children.length - 1];
+		target.focus();
+	}
+}
+
+// keyboard input
+window.addEventListener('keydown', function ({
+	key
+}) {
+	switch (key) {
+		case 'd':
+		case 'ArrowRight':
+			return onInput({
+				x: 1
+			});
+		case 'a':
+		case 'ArrowLeft':
+			return onInput({
+				x: -1
+			});
+		default:
+			return;
+	}
+});

--- a/src/mixtapePlayer.js
+++ b/src/mixtapePlayer.js
@@ -206,6 +206,7 @@ function restartGame() {
 // genericized input
 function onInput({
 	x = 0,
+	confirm = false,
 }) {
 	if (x > 0) {
 		const card = document.getElementById("card_" + selectedGameId);
@@ -215,6 +216,16 @@ function onInput({
 		const card = document.getElementById("card_" + selectedGameId);
 		const target = card.previousSibling || card.parentElement.children[card.parentElement.children.length - 1];
 		target.focus();
+	}
+
+	if (confirm) {
+		// HACK: this is a bit silly but works generically b/c if a card is selected,
+		// its double click listener will be triggered,
+		// and then the iframe will be clicked (doing nothing)
+		// or, a selected button will be doubleclicked (doing nothing),
+		// and then clicked, triggering standard behaviour
+		document.activeElement.dispatchEvent(new MouseEvent('dblclick'));
+		document.activeElement.dispatchEvent(new MouseEvent('click'));
 	}
 }
 
@@ -232,6 +243,12 @@ window.addEventListener('keydown', function ({
 		case 'ArrowLeft':
 			return onInput({
 				x: -1
+			});
+		case 'z':
+		case 'Enter':
+		case ' ':
+			return onInput({
+				confirm: true
 			});
 		default:
 			return;

--- a/src/mixtapePlayer.js
+++ b/src/mixtapePlayer.js
@@ -309,46 +309,50 @@ window.addEventListener('keydown', function ({
 // gamepad input
 
 const gamepads = window.inputGamepads;
-gamepads.init();
+if (!gamepads) {
+	console.warn('gamepad input API not found');
+} else {
+	gamepads.init();
 
-function gamepadUpdate() {
-	let x = 0;
-	let y = 0;
-	let confirm = false;
-	let cancel = false;
-	if (gamepads.isJustDown(gamepads.DPAD_RIGHT) || gamepads.axisJustPast(gamepads.LSTICK_H, 0.5, 1)) {
-		x += 1;
-	}
-	if (gamepads.isJustDown(gamepads.DPAD_LEFT) || gamepads.axisJustPast(gamepads.LSTICK_H, -0.5, -1)) {
-		x -= 1;
-	}
-	if (gamepads.isJustDown(gamepads.DPAD_DOWN) || gamepads.axisJustPast(gamepads.LSTICK_V, 0.5, 1)) {
-		y += 1;
-	}
-	if (gamepads.isJustDown(gamepads.DPAD_UP) || gamepads.axisJustPast(gamepads.LSTICK_V, -0.5, -1)) {
-		y -= 1;
-	}
-	if (gamepads.isJustDown(gamepads.A) || gamepads.isJustDown(gamepads.START)) {
-		confirm = true;
-	}
-	if (gamepads.isJustDown(gamepads.BACK)) {
-		cancel = true;
+	function gamepadUpdate() {
+		let x = 0;
+		let y = 0;
+		let confirm = false;
+		let cancel = false;
+		if (gamepads.isJustDown(gamepads.DPAD_RIGHT) || gamepads.axisJustPast(gamepads.LSTICK_H, 0.5, 1)) {
+			x += 1;
+		}
+		if (gamepads.isJustDown(gamepads.DPAD_LEFT) || gamepads.axisJustPast(gamepads.LSTICK_H, -0.5, -1)) {
+			x -= 1;
+		}
+		if (gamepads.isJustDown(gamepads.DPAD_DOWN) || gamepads.axisJustPast(gamepads.LSTICK_V, 0.5, 1)) {
+			y += 1;
+		}
+		if (gamepads.isJustDown(gamepads.DPAD_UP) || gamepads.axisJustPast(gamepads.LSTICK_V, -0.5, -1)) {
+			y -= 1;
+		}
+		if (gamepads.isJustDown(gamepads.A) || gamepads.isJustDown(gamepads.START)) {
+			confirm = true;
+		}
+		if (gamepads.isJustDown(gamepads.BACK)) {
+			cancel = true;
+		}
+
+		onInput({
+			x,
+			y,
+			confirm,
+			cancel,
+		});
+
+		gamepads.update();
 	}
 
-	onInput({
-		x,
-		y,
-		confirm,
-		cancel,
-	});
-
-	gamepads.update();
+	function loop(fn) {
+		(function l() {
+			fn();
+			requestAnimationFrame(l);
+		}());
+	}
+	loop(gamepadUpdate);
 }
-
-function loop(fn) {
-	(function l() {
-		fn();
-		requestAnimationFrame(l);
-	}());
-}
-loop(gamepadUpdate);

--- a/src/mixtapePlayer.js
+++ b/src/mixtapePlayer.js
@@ -207,6 +207,7 @@ function restartGame() {
 function onInput({
 	x = 0,
 	confirm = false,
+	cancel = false,
 }) {
 	if (x > 0) {
 		const card = document.getElementById("card_" + selectedGameId);
@@ -226,6 +227,11 @@ function onInput({
 		// and then clicked, triggering standard behaviour
 		document.activeElement.dispatchEvent(new MouseEvent('dblclick'));
 		document.activeElement.dispatchEvent(new MouseEvent('click'));
+	}
+
+	if (cancel) {
+		const exit = document.getElementById("play_exit_button");
+		exit && exit.onclick && exit.onclick();
 	}
 }
 
@@ -249,6 +255,11 @@ window.addEventListener('keydown', function ({
 		case ' ':
 			return onInput({
 				confirm: true
+			});
+		case 'x':
+		case 'Escape':
+			return onInput({
+				cancel: true
 			});
 		default:
 			return;

--- a/src/mixtapePlayer.js
+++ b/src/mixtapePlayer.js
@@ -206,6 +206,7 @@ function restartGame() {
 // genericized input
 function onInput({
 	x = 0,
+	y = 0,
 	confirm = false,
 	cancel = false,
 }) {
@@ -217,6 +218,35 @@ function onInput({
 		const card = document.getElementById("card_" + selectedGameId);
 		const target = card.previousSibling || card.parentElement.children[card.parentElement.children.length - 1];
 		target.focus();
+	}
+	if (y > 0) {
+		const card = document.getElementById("card_" + selectedGameId);
+		const { x: cx } = card.getBoundingClientRect();
+		const offset = Array.from(card.parentElement.children).indexOf(card);
+		for (let i = 1; i < card.parentElement.childElementCount; ++i) {
+			const target = card.parentElement.children[(offset+i)%card.parentElement.childElementCount];
+			const { x: tx } = target.getBoundingClientRect();
+			if (tx === cx) {
+				target.focus();
+				break;
+			}
+		}
+	} else if (y < 0) {
+		const card = document.getElementById("card_" + selectedGameId);
+		const { x: cx } = card.getBoundingClientRect();
+		const offset = Array.from(card.parentElement.children).indexOf(card);
+		for (let i = 1; i < card.parentElement.childElementCount; ++i) {
+			let idx = offset-i;
+			if (idx < 0) {
+				idx += card.parentElement.childElementCount;
+			}
+			const target = card.parentElement.children[idx];
+			const { x: tx } = target.getBoundingClientRect();
+			if (tx === cx) {
+				target.focus();
+				break;
+			}
+		}
 	}
 
 	if (confirm) {
@@ -249,6 +279,16 @@ window.addEventListener('keydown', function ({
 		case 'ArrowLeft':
 			return onInput({
 				x: -1
+			});
+		case 'w':
+		case 'ArrowUp':
+			return onInput({
+				y: -1
+			});
+		case 's':
+		case 'ArrowDown':
+			return onInput({
+				y: 1
 			});
 		case 'z':
 		case 'Enter':

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -66,6 +66,10 @@ h5 {
 	color: black;
 }
 
+.ui-btn:focus {
+	outline: solid 1px white;
+}
+
 .ui-btn .material-icons {
 	font-size: 18px;
 	vertical-align: middle;


### PR DESCRIPTION
- updates games to be played on doubleclick instead of single click while focused (simplifies things a bit, and i assume this was the original intent)
- updates games to be selected on focus instead of click (automatically adds rough keyboard support via tab-order)
- adds a small outline to focused ui buttons for accessibility
- adds "genericized" input function (maps `{ x, y, confirm, cancel }` input to navigating in the game grid, selecting a game, and exiting a game)
  - horizontal nav does ordered next/previous
  - vertical nav does positional up/down
  - confirm starts selected game
  - cancel exits current game
  - note: "play random" isn't mapped, but could be pretty easily if we wanted it (idk what buttons would make sense for that though)
- adds keyboard mapping for genericized input
  - WASD/arrows for nav, Z/enter/space for confim, X/exit for cancel
  - note that the "exit game" input here technically works, but not practically b/c the bitsy iframe grabs focus and eats the keyevents; the exit keyboard shortcut only works if you've unfocused it (works on the select screen too as a bonus "randomize" key, since exiting randomizes as a side effect)
- adds gamepad mapping for genericized input
  - dpad/left stick for nav, A/start for confim, back/select/share/the-not-"start"-one for cancel
  - you'll have to run `npm install` for this bit to work, but it's just referencing the scripts directly so will still work when run from source, and just logs a warning if the API isn't present
  - tested on "tea for two" (which already has the gamepad hack) with a wired xbox controller; seems to work seamlessly!